### PR TITLE
Fix tests

### DIFF
--- a/tests/test_pbx.py
+++ b/tests/test_pbx.py
@@ -1,4 +1,3 @@
-import pytest
 from pybibx.pybibx.base.pbx import pbx_probe
 
 def test_pbx_probe_initialization():


### PR DESCRIPTION
## Summary
- drop unused pytest import from tests

## Testing
- `ruff check tests/test_pbx.py`

------
https://chatgpt.com/codex/tasks/task_e_6865ae2a010c833194d6b9a6dca21150