### PR TITLE
Add missing data plotting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,20 @@ import pybibx
 
 # Your code here
 ```
+
+### Visualize Missing Data
+
+Install the optional visualization extras to enable `plot_missing`:
+
+```bash
+pip install pybibx[viz]
+```
+
+Then plot the missing values from a loaded bibliography:
+
+```python
+from pybibx.base.pbx import pbx_probe
+
+probe = pbx_probe("sample.bib")
+probe.plot_missing()
+```

--- a/pybibx/base/pbx.py
+++ b/pybibx/base/pbx.py
@@ -4776,6 +4776,21 @@ class pbx_probe:
         plt.show()
         return
 
+    # Function: Plot Missing Values
+    def plot_missing(self, method="matrix"):
+        try:
+            import missingno as msno
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError(
+                "The 'missingno' package is required for this feature. Install it via 'pip install pybibx[viz]'"
+            )
+        if method == "heatmap":
+            msno.heatmap(self.data)
+        else:
+            msno.matrix(self.data)
+        plt.show()
+        return
+
     # Function: Get Top N-Grams
     def get_top_ngrams(
         self,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,6 @@ dev = [
     "ruff>=0.1.0",
     "mkdocs>=1.4.0",
 ]
+viz = [
+    "missingno"
+]

--- a/tests/test_pbx.py
+++ b/tests/test_pbx.py
@@ -1,5 +1,5 @@
 import pytest
-from pybibx.pybibx.base.pbx import pbx_probe
+from pybibx.base.pbx import pbx_probe
 
 def test_pbx_probe_initialization():
     # This is a basic smoke test to ensure the class can be instantiated.


### PR DESCRIPTION
## Summary
- declare optional dependency `missingno`
- add `plot_missing` helper in `pbx_probe`
- document the helper in README
- fix import in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678eb2ca648331bc4200f87680dfac