### PR TITLE
Handle PubMed reference splitting

### DIFF
--- a/tests/test_pbx.py
+++ b/tests/test_pbx.py
@@ -1,13 +1,20 @@
 import pytest
-from pybibx.pybibx.base.pbx import pbx_probe
+from pybibx.base.pbx import pbx_probe, _split_references
 
 def test_pbx_probe_initialization():
     # This is a basic smoke test to ensure the class can be instantiated.
     # A more comprehensive test would require a sample .bib file.
     try:
-        probe = pbx_probe(file_bib='sample.bib')
+        probe = pbx_probe(file_bib="sample.bib")
         assert probe is not None
     except FileNotFoundError:
         # This is expected since 'sample.bib' does not exist.
         # The goal of this test is to ensure the class can be imported and initialized without errors.
         pass
+
+
+def test_split_references_pubmed():
+    text = "Lancet. 2011 Feb 12;377(9765):551-2"
+    refs = _split_references(text, "pubmed")
+    assert refs == [text]
+


### PR DESCRIPTION
## Summary
- add `_split_references` helper to split reference strings depending on the data source
- use the helper within `__get_str`
- update tests for new helper and fix pbx import path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'bertopic')*

------
https://chatgpt.com/codex/tasks/task_e_686776a0c1308331921484584a79cea2